### PR TITLE
n+1 and whitelisted has_toast options

### DIFF
--- a/lib/toastr/has_toast.rb
+++ b/lib/toastr/has_toast.rb
@@ -3,22 +3,27 @@ module Toastr
     extend ActiveSupport::Concern
 
     module ClassMethods
+      HAS_TOAST_OPTIONS_WHITELIST = [:empty_cache_json, :expire_in, :expire_if]
       def has_toast(category, options = {})
         has_many :toasts, class_name: Toastr::Toast, as: :parent, dependent: :destroy
+
+        if (unrecognized_options = options.symbolize_keys!.keys - HAS_TOAST_OPTIONS_WHITELIST).any?
+          raise ArgumentError.new "Unrecognized option(s): #{unrecognized_options.collect{|o| ':' + o.to_s}.join(', ')}. Allowed options are #{HAS_TOAST_OPTIONS_WHITELIST.collect{|o| ':' + o.to_s}.join(', ')}"
+        end
 
         begin
           alias_method "#{category}_for_toastr", category
         rescue
-          raise ArgumentError.new "#{category} must be a defined instance method"
+          raise ArgumentError.new ":#{category} must be an already-defined instance method"
         end
 
         define_method category do
-          raise 'Gotta persist activerecord first' unless self.persisted?
+          raise "Record must be persisted in database before calling method :#{category}" unless self.persisted?
           toast = self.toasts.where(category: category).first_or_create
 
           case toast.status.to_sym
           when :cached
-            Toastr.queue_if_stale!(self, toast, options)
+            Toastr.queue_if_stale!(self, toast, options.slice(:expire_in, :expire_if))
             toast.cache_json
           when :empty
             toast.queue!

--- a/lib/toastr/has_toast.rb
+++ b/lib/toastr/has_toast.rb
@@ -19,7 +19,7 @@ module Toastr
 
         define_method category do
           raise "Record must be persisted in database before calling method :#{category}" unless self.persisted?
-          toast = self.toasts.where(category: category).first_or_create
+          toast = self.toasts.select{|t| t.category.to_s == category.to_s}.last || self.toasts.create(category: category)
 
           case toast.status.to_sym
           when :cached

--- a/test/dummy/test/models/oat_test.rb
+++ b/test/dummy/test/models/oat_test.rb
@@ -95,7 +95,7 @@ class OatTest < ActiveSupport::TestCase
     4.times do
       Oat.create!
     end
-    assert_equal 5, Oat.count # plus one fixture
+    assert_equal 5, Oat.count # 4 plus one pre-existing fixture
 
     # build toasts
     Oat.all.each(&:daily_report)

--- a/test/dummy/test/models/oat_test.rb
+++ b/test/dummy/test/models/oat_test.rb
@@ -20,14 +20,14 @@ class OatTest < ActiveSupport::TestCase
 
   test 'default toast doesnt update toast if not stale' do
     @oat.breakfast
-    updated_at = @oat.toasts.last.updated_at
+    updated_at = @oat.toasts.last.reload.updated_at
     @oat.breakfast
     assert_equal updated_at, @oat.toasts.last.reload.updated_at
   end
 
   test 'default toast updates if stale' do
     @oat.breakfast
-    updated_at = @oat.toasts.last.updated_at
+    updated_at = @oat.toasts.last.reload.updated_at
     @oat.breakfast
     @oat.touch
     @oat.breakfast
@@ -48,16 +48,16 @@ class OatTest < ActiveSupport::TestCase
 
   test 'expires_in toast doesnt update toast if not stale' do
     @oat.daily_report
-    updated_at = @oat.toasts.last.updated_at
+    updated_at = @oat.toasts.last.reload.updated_at
     assert_equal 'result', @oat.daily_report['different']
     assert_equal updated_at, @oat.toasts.last.reload.updated_at
   end
 
   test 'expires_in toast updates if stale' do
     @oat.daily_report
-    updated_at = @oat.toasts.last.updated_at
-    @oat.toasts.last.update_column :updated_at, 2.days.ago # 1.day is the expiration
-    assert_equal 'result', @oat.daily_report['different']
+    updated_at = @oat.toasts.last.reload.updated_at
+    @oat.toasts.last.update_column :updated_at, 2.days.ago # 1.day.ago is the expiration
+    assert_equal 'result', @oat.reload.daily_report['different']
     assert_not_equal updated_at, @oat.toasts.last.reload.updated_at
   end
 
@@ -76,7 +76,7 @@ class OatTest < ActiveSupport::TestCase
   test 'arbitrary block toast doesnt update toast if not stale' do
     @oat.special
     @oat.update! created_at: '2015-01-01'
-    updated_at = @oat.toasts.last.updated_at
+    updated_at = @oat.toasts.last.reload.updated_at
     assert_equal 'special', @oat.special['very']
     assert_equal updated_at, @oat.toasts.last.reload.updated_at
   end
@@ -84,8 +84,26 @@ class OatTest < ActiveSupport::TestCase
   test 'arbitrary block toast updates if stale' do
     @oat.special
     @oat.update! created_at: '2015-01-08'
-    updated_at = @oat.toasts.last.updated_at
-    assert_equal 'special', @oat.special['very']
+    updated_at = @oat.toasts.last.reload.updated_at
+    assert_equal 'special', @oat.reload.special['very']
     assert_not_equal updated_at, @oat.toasts.last.reload.updated_at
   end
+
+  # other tests
+
+  test 'avoids n+1 by allowing MyActiveRecord.includes(:toasts)...' do
+    4.times do
+      Oat.create!
+    end
+    assert_equal 5, Oat.count # plus one fixture
+
+    # build toasts
+    Oat.all.each(&:daily_report)
+
+    count = count_queries do
+      Oat.all.includes(:toasts).each(&:daily_report)
+    end
+    assert_equal 2, count
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,17 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 if ActiveSupport::TestCase.method_defined?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 end
+
+class ActiveSupport::TestCase
+  def count_queries &block
+    count = 0
+
+    counter_f = ->(name, started, finished, unique_id, payload) {
+      unless payload[:name].in? %w[ CACHE SCHEMA ]
+        count += 1
+      end
+    }
+    ActiveSupport::Notifications.subscribed(counter_f, "sql.active_record", &block)
+    count
+  end
+end


### PR DESCRIPTION
- avoids n+1 queries by using eager-loaded toasts
- Whitelisted options for :has_toast. Errors at load time if invalid options specified.
